### PR TITLE
Erro em rpsSignatureString impede emissão de NF-e p/ CPF

### DIFF
--- a/src/Helpers/Certificate.php
+++ b/src/Helpers/Certificate.php
@@ -79,7 +79,6 @@ class Certificate
             sprintf('%015s', str_replace(array('.', ','), '', number_format(General::getKey($params, RpsEnum::DEDUCTION_VALUE), 2))) .
             sprintf('%05s', General::getKey($params, RpsEnum::SERVICE_CODE)) .
             ((General::getKey($params, SimpleFieldsEnum::CPF)) ? 1 : 2) .
-            General::getKey($params, SimpleFieldsEnum::CPF) .
             sprintf('%014s', $document);
 
         // AVAILABLE ON RELEASE 2


### PR DESCRIPTION
Segundo manual da prefeitura, o CPF/CNPJ vem na sequência do indicador (1 ou 2).

O código estava inserindo o CPJ (11 dígitos) e depois o campo correto de 14 dígitos.

Funciona p/ CNPJ provavelmente porque nesse caso o CPF é nulo.

A similar PR may already be submitted!
Please search among the [Pull request](../) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
